### PR TITLE
Add id to resource descriptor

### DIFF
--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
@@ -16,5 +16,25 @@
 
 package org.creekservice.api.platform.metadata;
 
+
+import java.net.URI;
+
 /** Marker interface of resource descriptors. */
-public interface ResourceDescriptor {}
+public interface ResourceDescriptor {
+
+    /**
+     * A unique identifier for this resource.
+     *
+     * <p>To avoid URI clashes between resources from different extensions, the URI scheme will
+     * normally be prefixed with the name of the extension that managed the resource. For example,
+     * the Kafka extension's topic resource's scheme is {@code kafka-topic}.
+     *
+     * <p>The form of the rest of the URI is up the extension implementer.
+     *
+     * <p>The core Creek system will use the id to determine if two descriptors refer to the same
+     * resource. It will not inspect or use the parts of the URI.
+     *
+     * @return unique identifier for the resource.
+     */
+    URI id();
+}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
@@ -34,6 +34,10 @@ public interface ResourceDescriptor {
      * <p>The core Creek system will use the id to determine if two descriptors refer to the same
      * resource. It will not inspect or use the parts of the URI.
      *
+     * <p>{@link ComponentInput Input}, {@link ComponentInternal internal} & {@link ComponentOutput
+     * output} resource descriptors that refer to the same underlying resource must return the same
+     * URI.
+     *
      * @return unique identifier for the resource.
      */
     URI id();


### PR DESCRIPTION
...as this will allow descriptors to be grouped by the resource they represent, i.e. the code can tell if two descriptors refer to the same resource, _without_ having to inspect the other fields of the descriptors.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended