### PR TITLE
Make `ComponentValidator` internal

### DIFF
--- a/metadata/README.md
+++ b/metadata/README.md
@@ -56,12 +56,13 @@ Resource descriptors define the resources a component uses in its [inputs](#inpu
 There are corresponding `ComponentInput`, `ComponentInternal` and `ComponentOutput` marker interfaces, respectively. 
 
 Authors of creek services are not expected to implement the above marker interfaces. Creek extensions, 
-(such as [creek-kafka][1]), expose their own interfaces, which extend the marker interfaces, and which can be used to 
+(such as [creek-kafka][1]), expose their own interfaces, which extend these marker interfaces, and which can be used to 
 define a resource the component uses, e.g. a Kafka Topic.
 
 > ### NOTE
-> Extensions expose resource _interfaces_ rather than _classes_ to keep code coupling to a minimum, minimising chances of 
-> dependency hell, etc.
+> The reason extensions expose resource _interfaces_ rather than _classes_ is to keep code coupling to a minimum, 
+> thereby minimising chances of dependency hell. Extensions provide example code that can be cut & paste for
+> creating the required implementations.
 
 ### Resource initialization
 
@@ -92,17 +93,23 @@ When the service starts, Creek will automatically create the resource when initi
 > Future plans are to support a mode where owned resources are created by an initialization tool, prior to deployment.
 > See [issue-68][2].
 
+The owned resource types provided by extensions will define helper methods to obtain an unowned descriptor from an
+owned one. For example, the `OwnedKafkaTopicOutput` has a `toInput` method to obtain an unowned `KafkaTopicInput`.
+
 ##### Unowned Resources
 
 Resources tagged with the `UnownedResource` interface are conceptually owns by another service.
 
 For example, services generally consume Kafka the _owned_ output topics of upstream services. 
 Therefore, the service's descriptor will define an _unowned_ descriptor for such resource, e.g. defining the
-topic name, key & value types, partition count, etc. The unowned descriptor is created by calling `toInput` on 
-the owned descriptor.
+topic name, key & value types, partition count, etc. 
 
 When the service starts, Creek will _not_ initialize unowned resources.
- 
+
+Unowned resource types provided by extensions should not normally be directly created. Instead, the unowned descriptor 
+should be created by calling an appropriate helper method on the owned resource. For example, an unowned `KafkaTopicInput`
+is obtained by calling `toInput` on the associated `OwnedKafkaTopicOutput`. 
+
 ##### Shared Resources
 
 Resources tagged with the `SharedResource` interface are conceptually not owned by any service.
@@ -112,6 +119,10 @@ that wish to use it.
 
 Shared resources are initialised via the [Init tool](https://github.com/creek-service/creek-platform/issues/7) before 
 any service that requires them are deployed.
+
+Shared resource types provided by extensions will implement the `ComponentInput`, `ComponentInternal` and/or `ComponentOutput` 
+interfaces, as appropriate for the resource type.  This allows a shared single definition to be used directly as a component's
+input, internal or output.
 
 ##### Unmanaged Resources
 

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceHandler.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceHandler.java
@@ -51,11 +51,11 @@ public interface ResourceHandler<T extends ResourceDescriptor> {
      * <p>Instructs an extension to ensure the resources described by the supplied descriptor exist
      * and are initialized.
      *
-     * <p>Implementations should consider outputting a warning or failing if the resource alreay
+     * <p>Implementations should consider outputting a warning or failing if the resource already
      * exists, but does not match the expected configuration.
      *
-     * @param resources the resource instances to ensure exists and are initialized. Resources must
-     *     be {@link ResourceDescriptor#isCreatable creatable}.
+     * @param resources the resource instances to ensure exists and are initialized. Resources
+     *     passed will be {@link ResourceDescriptor#isCreatable creatable}.
      */
     void ensure(Collection<T> resources);
 }

--- a/resource/src/main/java/org/creekservice/api/platform/resource/ResourceInitializer.java
+++ b/resource/src/main/java/org/creekservice/api/platform/resource/ResourceInitializer.java
@@ -22,7 +22,6 @@ import static org.creekservice.api.platform.metadata.ResourceDescriptor.isOwned;
 import static org.creekservice.api.platform.metadata.ResourceDescriptor.isShared;
 import static org.creekservice.api.platform.metadata.ResourceDescriptor.isUnmanaged;
 import static org.creekservice.api.platform.metadata.ResourceDescriptor.isUnowned;
-import static org.creekservice.api.platform.resource.ComponentValidator.componentValidator;
 
 import java.net.URI;
 import java.util.Collection;
@@ -37,6 +36,7 @@ import org.creekservice.api.base.type.CodeLocation;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ResourceDescriptor;
 import org.creekservice.api.platform.metadata.ResourceHandler;
+import org.creekservice.internal.platform.resource.ComponentValidator;
 
 /**
  * Initializer of resources.
@@ -67,7 +67,7 @@ public final class ResourceInitializer {
      * @return an initializer instance.
      */
     public static ResourceInitializer resourceInitializer(final ResourceHandlers handlers) {
-        return new ResourceInitializer(handlers, componentValidator());
+        return new ResourceInitializer(handlers, new ComponentValidator());
     }
 
     @VisibleForTesting

--- a/resource/src/main/java/org/creekservice/internal/platform/resource/ComponentValidator.java
+++ b/resource/src/main/java/org/creekservice/internal/platform/resource/ComponentValidator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.platform.resource;
+package org.creekservice.internal.platform.resource;
 
 
 import java.lang.reflect.Method;
@@ -36,11 +36,7 @@ public final class ComponentValidator {
 
     private static final Pattern CTRL_CHAR = Pattern.compile("\\p{Cntrl}");
 
-    public static ComponentValidator componentValidator() {
-        return new ComponentValidator();
-    }
-
-    private ComponentValidator() {}
+    public ComponentValidator() {}
 
     public void validate(final ComponentDescriptor... components) {
         Arrays.stream(components).forEach(this::validateComponent);

--- a/resource/src/test/java/org/creekservice/api/platform/resource/ResourceInitializerTest.java
+++ b/resource/src/test/java/org/creekservice/api/platform/resource/ResourceInitializerTest.java
@@ -40,6 +40,7 @@ import org.creekservice.api.platform.metadata.ResourceDescriptor;
 import org.creekservice.api.platform.metadata.ResourceHandler;
 import org.creekservice.api.platform.metadata.SharedResource;
 import org.creekservice.api.platform.metadata.UnownedResource;
+import org.creekservice.internal.platform.resource.ComponentValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/resource/src/test/java/org/creekservice/internal/platform/resource/ComponentValidatorTest.java
+++ b/resource/src/test/java/org/creekservice/internal/platform/resource/ComponentValidatorTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.platform.resource;
+package org.creekservice.internal.platform.resource;
 
-import static org.creekservice.api.platform.resource.ComponentValidator.componentValidator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.matchesRegex;
@@ -60,7 +59,7 @@ class ComponentValidatorTest {
     @Mock(name = "jane")
     private AggregateDescriptor aggregate;
 
-    private final ComponentValidator validator = componentValidator();
+    private final ComponentValidator validator = new ComponentValidator();
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
...as its no longer used outside of the `ResourceInitializer`.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended