### PR TITLE
Remove validate call from `ResourceHandler`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ subprojects {
 
     project.version = project.parent?.version!!
 
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor(10, TimeUnit.MINUTES)
+    }
+
     extra.apply {
         set("creekBaseVersion", "0.2.0-SNAPSHOT")
         set("creekTestVersion", "0.2.0-SNAPSHOT")

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceHandler.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceHandler.java
@@ -27,25 +27,6 @@ import java.util.Collection;
 public interface ResourceHandler<T extends ResourceDescriptor> {
 
     /**
-     * Validate a group of descriptors that should reference the same resource.
-     *
-     * <p>First the method performs a one time validation of each resource instance, called before
-     * any other methods, to allow the extension to validate each descriptor instance. This is
-     * necessary as resources are implemented by client code and therefore could be invalid.
-     *
-     * <p>Second, where the group contains more than one descriptor, the method validates that each
-     * descriptor in the group agrees on the details of the resource. If descriptors differ on the
-     * details it means something is out of whack in the system, and this needs resolving before
-     * things can continue.
-     *
-     * @param resourceGroup a collection of resource descriptors that should all describe the same
-     *     resource.
-     * @throws RuntimeException implementations should throw a suitable exception type on any
-     *     validation failures, providing enough information for users to resolve the issue.
-     */
-    void validate(Collection<? extends T> resourceGroup);
-
-    /**
      * Ensure the supplied {@code resources} exists.
      *
      * <p>Instructs an extension to ensure the resources described by the supplied descriptor exist

--- a/resource/src/main/java/org/creekservice/api/platform/resource/ResourceInitializer.java
+++ b/resource/src/main/java/org/creekservice/api/platform/resource/ResourceInitializer.java
@@ -179,11 +179,8 @@ public final class ResourceInitializer {
     }
 
     /**
-     * Validate a group of descriptors that describe the same resource, ensuring they are
-     * consistent.
-     *
-     * <p>When dealing with multiple components, the same resource can be described by multiple
-     * descriptors. All descriptors should agree on the details of the resource.
+     * Validate a group of descriptors that describe the same resource, ensuring they are consistent
+     * on how the resource is initialized.
      *
      * @param resourceGroup the group of descriptors that describe the same resource.
      */
@@ -207,8 +204,6 @@ public final class ResourceInitializer {
                         "owned or unowned", resourceGroup);
             }
         }
-
-        resourceHandler(resourceGroup.get(0)).validate(resourceGroup);
     }
 
     @SuppressWarnings("unchecked")

--- a/resource/src/test/java/org/creekservice/api/platform/resource/ResourceInitializerTest.java
+++ b/resource/src/test/java/org/creekservice/api/platform/resource/ResourceInitializerTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -306,48 +305,6 @@ class ResourceInitializerTest {
     }
 
     @Test
-    void shouldValidateSharedGroup() {
-        // Given:
-        final ResourceA sharedResource1b = resourceA(1, SharedResource.class);
-        when(component0.resources()).thenReturn(Stream.of(sharedResource1));
-        when(component1.resources()).thenReturn(Stream.of(sharedResource1b));
-
-        // When:
-        initializer.init(List.of(component0, component1));
-
-        // Then:
-        verify(handlerA).validate(List.of(sharedResource1, sharedResource1b));
-    }
-
-    @Test
-    void shouldValidateOwnedAndUnownedGroup() {
-        // Given:
-        when(component0.resources()).thenReturn(Stream.of(unownedResource1));
-        when(component1.resources()).thenReturn(Stream.of(ownedResource1));
-
-        // When:
-        initializer.test(List.of(component0), List.of(component1));
-
-        // Then:
-        verify(handlerA, atLeastOnce()).validate(List.of(unownedResource1, ownedResource1));
-    }
-
-    @Test
-    void shouldThrowIfResourceGroupValidationFails() {
-        // Given:
-        final RuntimeException expected = new RuntimeException("boom");
-        doThrow(expected).when(handlerA).validate(any());
-        when(component0.resources()).thenReturn(Stream.of(sharedResource1));
-
-        // When:
-        final Exception e =
-                assertThrows(RuntimeException.class, () -> initializer.init(List.of(component0)));
-
-        // Then:
-        assertThat(e, is(sameInstance(expected)));
-    }
-
-    @Test
     void shouldThrowOnUncreatableResource() {
         // Given:
         when(component0.resources()).thenReturn(Stream.of(unownedResource1));
@@ -445,79 +402,6 @@ class ResourceInitializerTest {
         // Then:
         verify(handlerA).ensure(List.of(ownedResource1));
         verify(handlerB).ensure(List.of(ownedResourceB));
-    }
-
-    @Test
-    void shouldValidateServiceSharedResourceGroups() {
-        // Given:
-        final ResourceA resource2 = resourceA(1, SharedResource.class);
-        when(component0.resources()).thenReturn(Stream.of(sharedResource1, resource2));
-
-        // When:
-        initializer.service(List.of(component0));
-
-        // Then:
-        verify(handlerA).validate(List.of(sharedResource1, resource2));
-    }
-
-    @Test
-    void shouldValidateServiceUnownedResourceGroups() {
-        // Given:
-        final ResourceA resource2 = resourceA(1, UnownedResource.class);
-        when(component0.resources()).thenReturn(Stream.of(unownedResource1, resource2));
-
-        // When:
-        initializer.service(List.of(component0));
-
-        // Then:
-        verify(handlerA).validate(List.of(unownedResource1, resource2));
-    }
-
-    @Test
-    void shouldValidateServiceUnmanagedResourceGroups() {
-        // Given:
-        when(component0.resources()).thenReturn(Stream.of(unmanagedResource1));
-
-        // When:
-        initializer.service(List.of(component0));
-
-        // Then:
-        verify(handlerA).validate(List.of(unmanagedResource1));
-    }
-
-    @Test
-    void shouldValidateTestSharedResourceGroupsForComponentsUnderTestOnly() {
-        // Given:
-        final ResourceA resource2 = resourceA(1, SharedResource.class);
-        final ResourceA resource3 = resourceA(1, SharedResource.class);
-        when(component0.resources()).thenReturn(Stream.of(sharedResource1, resource2));
-        when(component1.resources()).thenReturn(Stream.of(resource3));
-
-        // When:
-        initializer.test(List.of(component0), List.of(component1));
-
-        // Then:
-        verify(handlerA).validate(List.of(sharedResource1, resource2));
-    }
-
-    @Test
-    void shouldValidateTestUnmanagedResourceGroupsForComponentsUnderTestOnly() {
-        // Given:
-        final ResourceA resource2 = resourceA(1);
-        final ResourceA resource3 = resourceA(1);
-        when(component0.resources()).thenReturn(Stream.of(unmanagedResource1, resource2));
-        when(component1.resources()).thenReturn(Stream.of(resource3));
-
-        // When:
-        initializer.test(List.of(component0), List.of(component1));
-
-        // Then:
-        verify(handlerA).validate(List.of(unmanagedResource1, resource2));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static ResourceA resourceA(final int id) {
-        return resourceA(id, withSettings());
     }
 
     private static ResourceA resourceA(final int id, final Class<?> extraInterface) {


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-kafka/issues/56

Given a service extension will be passed all components under test as part of the api passed to the initialize call, and that the extension will use the components' resource descriptors to initialize itself, and will therefore need to validate descriptors and that this is done _before_ the resource initializer can call validate... there is no point to then calling validate again here.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended