### PR TITLE
Support nested resources

### DIFF
--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -8,10 +8,4 @@
         <!-- Exclude generated sources   -->
         <Source name="~.*[\\/]build[\\/]generated[\\/]source.*" />
     </Match>
-
-    <Match>
-        <!-- Disable this check as it leads to longer names and harder to read code -->
-        <!-- Discussion: https://github.com/spotbugs/spotbugs/issues/2627 -->
-        <Bug pattern="PI_DO_NOT_REUSE_PUBLIC_IDENTIFIERS_CLASS_NAMES"/>
-    </Match>
 </FindBugsFilter>

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -23,22 +23,19 @@ Authors of Creek based services will build implementations of both aggregate and
 
 The inputs of a component define any external resources the component consumes/reads.
 
-All input resources implement the [`ComponentInput`](src/main/java/org/creekservice/api/platform/metadata/ComponentInput.java)
-marker interface.
+All input resources implement the [`ComponentInput`](src/main/java/org/creekservice/api/platform/metadata/ComponentInput.java) interface.
 
 ### Internals
 
 The internals of a component define any external resources the component uses internally to perform its function.
 
-All internal resources implement the [`ComponentInternal`](src/main/java/org/creekservice/api/platform/metadata/ComponentInternal.java)
-marker interface.
+All internal resources implement the [`ComponentInternal`](src/main/java/org/creekservice/api/platform/metadata/ComponentInternal.java) interface.
 
 ### Outputs
 
 The outputs of a component define any external resources the component produces/writes.
 
-All output resources implement the [`ComponentOutput`](src/main/java/org/creekservice/api/platform/metadata/ComponentOutput.java)
-marker interface.
+All output resources implement the [`ComponentOutput`](src/main/java/org/creekservice/api/platform/metadata/ComponentOutput.java) interface.
 
 ### Service descriptors
 
@@ -55,10 +52,10 @@ to define their public [inputs](#inputs) and [outputs](#outputs).
 ## Resource Descriptors
 
 Resource descriptors define the resources a component uses in its [inputs](#inputs), [internals](#internals) and [outputs](#outputs).
-There are corresponding `ComponentInput`, `ComponentInternal` and `ComponentOutput` marker interfaces, respectively. 
+There are corresponding `ComponentInput`, `ComponentInternal` and `ComponentOutput` interfaces, respectively. 
 
-Authors of creek services are not expected to implement the above marker interfaces. Creek extensions, 
-(such as [creek-kafka][1]), expose their own interfaces, which extend these marker interfaces, and which can be used to 
+Authors of creek services are not expected to implement the above interfaces. Creek extensions, 
+(such as [creek-kafka][1]), expose their own interfaces, which extend these interfaces, and which can be used to 
 define a resource the component uses, e.g. a Kafka Topic.
 
 > ### NOTE
@@ -128,7 +125,7 @@ input, internal or output.
 
 ##### Unmanaged Resources
 
-Any resource descriptor that does not implement one of the resource initialization marker interfaces are deemed not 
+Any resource descriptor that does not implement one of the resource initialization interfaces are deemed not 
 to be initialized by Creek. Such resources must be initialized some other way.
 
 #### Resource deployment

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentDescriptor.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  *   <li>both of the above
  * </ul>
  */
-public interface ComponentDescriptor {
+public interface ComponentDescriptor extends ResourceCollection {
 
     /**
      * @return the unique name of the component within the platform. Can not be {@code null}, blank

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentInput.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentInput.java
@@ -16,5 +16,5 @@
 
 package org.creekservice.api.platform.metadata;
 
-/** Marker interface of component inputs. */
+/** Base type for component inputs. */
 public interface ComponentInput extends ResourceDescriptor {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentInternal.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentInternal.java
@@ -16,5 +16,5 @@
 
 package org.creekservice.api.platform.metadata;
 
-/** Marker interface of component internals. */
+/** Base type for component internals. */
 public interface ComponentInternal extends ResourceDescriptor {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentOutput.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ComponentOutput.java
@@ -16,5 +16,5 @@
 
 package org.creekservice.api.platform.metadata;
 
-/** Marker interface of component outputs. */
+/** Base type for component outputs. */
 public interface ComponentOutput extends ResourceDescriptor {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/CreatableResource.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/CreatableResource.java
@@ -16,5 +16,10 @@
 
 package org.creekservice.api.platform.metadata;
 
-/** Marker interface to indicate a resource is {@link ResourceDescriptor#isCreatable creatable}. */
-interface CreatableResource {}
+/**
+ * Base type for creatable resources.
+ *
+ * <p>Extensions should not implement this directly. Instead, implement one of this interface's
+ * subtypes, e.g. {@link OwnedResource} or {@link SharedResource}.
+ */
+public interface CreatableResource extends ResourceDescriptor {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/OwnedResource.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/OwnedResource.java
@@ -17,7 +17,7 @@
 package org.creekservice.api.platform.metadata;
 
 /**
- * Marker interface of an owned resources.
+ * Base type for an owned resources.
  *
  * <p>A resource can conceptually be either:
  *
@@ -30,7 +30,7 @@ package org.creekservice.api.platform.metadata;
  *
  * <p>Resources should inherit <b>at most</b> one of the above interfaces.
  *
- * <p>For more information on resource initialization, see
- * https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization.
+ * <p>For more information on resource initialization, see <a
+ * href="https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization">resource-initialization</a>.
  */
 public interface OwnedResource extends CreatableResource {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceCollection.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceCollection.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.platform.metadata;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/** A collection of resources. */
+public interface ResourceCollection {
+
+    /**
+     * The stream of the resources in the collection.
+     *
+     * <p>In general, callers should call {@link #collectResources(ResourceCollection)}, rather than
+     * directly calling this method.
+     *
+     * @return the resources in the collection.
+     */
+    Stream<? extends ResourceDescriptor> resources();
+
+    /**
+     * Utility method to collect all resources from a collection, including any resources referenced
+     * by any resources encountered.
+     *
+     * <p>Child resources are returned earlier in the stream than parents.
+     *
+     * @param collection the resource collection to retrieve all resources from.
+     * @return complete stream of resources.
+     */
+    static Stream<ResourceDescriptor> collectResources(final ResourceCollection collection) {
+        final Set<ResourceCollection> visited = new HashSet<>();
+        visited.add(collection);
+        return collection.resources().flatMap(child -> collectResources(child, visited));
+    }
+
+    /**
+     * Utility method to collect all resources referenced by a {@code ResourceDescriptor}, including
+     * any resources referenced by any resources encountered.
+     *
+     * <p>Child resources are returned earlier in the stream than parents.
+     *
+     * <p>In general, callers should call {@link #collectResources(ResourceCollection)}, rather than
+     * directly calling this method.
+     *
+     * @param resource the resource descriptor to retrieve all resources from.
+     * @param visited the set of resource containers already visited.
+     * @return complete stream of resources.
+     */
+    static Stream<ResourceDescriptor> collectResources(
+            final ResourceDescriptor resource, final Set<ResourceCollection> visited) {
+        if (!visited.add(resource)) {
+            // Already processed:
+            return Stream.empty();
+        }
+
+        return Stream.concat(
+                resource.resources().flatMap(child -> collectResources(child, visited)),
+                Stream.of(resource));
+    }
+}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/ResourceDescriptor.java
@@ -17,9 +17,10 @@
 package org.creekservice.api.platform.metadata;
 
 import java.net.URI;
+import java.util.stream.Stream;
 
-/** Marker interface of resource descriptors. */
-public interface ResourceDescriptor {
+/** Base type for describing resource. */
+public interface ResourceDescriptor extends ResourceCollection {
 
     /**
      * A unique identifier for this resource.
@@ -42,50 +43,19 @@ public interface ResourceDescriptor {
     URI id();
 
     /**
-     * Determine if a resource descriptor is creatable.
+     * Additional resources this resource requires.
      *
-     * @param r the resource descriptor to check.
-     * @return {@code true} if creatable, {@code false} otherwise.
+     * @return stream of resources this resource depends on.
      */
-    static boolean isCreatable(final ResourceDescriptor r) {
-        return r instanceof CreatableResource;
-    }
-
-    /**
-     * Determine if a resource descriptor is marked owned.
-     *
-     * @param r the resource descriptor to check.
-     * @return {@code true} if creatable, {@code false} otherwise.
-     */
-    static boolean isOwned(final ResourceDescriptor r) {
-        return r instanceof OwnedResource;
-    }
-
-    /**
-     * Determine if a resource descriptor is unowned.
-     *
-     * @param r the resource descriptor to check.
-     * @return {@code true} if creatable, {@code false} otherwise.
-     */
-    static boolean isUnowned(final ResourceDescriptor r) {
-        return r instanceof UnownedResource;
-    }
-
-    /**
-     * Determine if a resource descriptor is shared.
-     *
-     * @param r the resource descriptor to check.
-     * @return {@code true} if creatable, {@code false} otherwise.
-     */
-    static boolean isShared(final ResourceDescriptor r) {
-        return r instanceof SharedResource;
+    default Stream<? extends ResourceDescriptor> resources() {
+        return Stream.of();
     }
 
     /**
      * Determine if a resource descriptor is unmanaged.
      *
      * @param r the r descriptor to check.
-     * @return {@code true} if creatable, {@code false} otherwise.
+     * @return {@code true} if unmanaged, {@code false} otherwise.
      */
     static boolean isUnmanaged(final ResourceDescriptor r) {
         return !(r instanceof SharedResource

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/SharedResource.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/SharedResource.java
@@ -17,7 +17,7 @@
 package org.creekservice.api.platform.metadata;
 
 /**
- * Marker interface of an owned resources.
+ * Base type for shared resources.
  *
  * <p>A resource can conceptually be either:
  *
@@ -30,7 +30,7 @@ package org.creekservice.api.platform.metadata;
  *
  * <p>Resources should inherit <b>at most</b> one of the above interfaces.
  *
- * <p>For more information on resource initialization, see
- * https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization.
+ * <p>For more information on resource initialization, see <a
+ * href="https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization">resource-initialization</a>.
  */
 public interface SharedResource extends CreatableResource {}

--- a/metadata/src/main/java/org/creekservice/api/platform/metadata/UnownedResource.java
+++ b/metadata/src/main/java/org/creekservice/api/platform/metadata/UnownedResource.java
@@ -17,7 +17,7 @@
 package org.creekservice.api.platform.metadata;
 
 /**
- * Marker interface of an unowned resources.
+ * Base type for unowned resources.
  *
  * <p>A resource can conceptually be either:
  *
@@ -30,7 +30,7 @@ package org.creekservice.api.platform.metadata;
  *
  * <p>Resources should inherit <b>at most</b> one of the above interfaces.
  *
- * <p>For more information on resource initialization, see
- * https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization.
+ * <p>For more information on resource initialization, see <a
+ * href="https://github.com/creek-service/creek-platform/tree/main/metadata#resource-initialization">resource-initialization</a>
  */
-public interface UnownedResource {}
+public interface UnownedResource extends ResourceDescriptor {}

--- a/metadata/src/test/java/org/creekservice/api/platform/metadata/ResourceCollectionTest.java
+++ b/metadata/src/test/java/org/creekservice/api/platform/metadata/ResourceCollectionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.platform.metadata;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceCollectionTest {
+
+    @Mock(extraInterfaces = {ResourceDescriptor.class})
+    private ResourceCollection collection;
+
+    @Mock private ResourceDescriptor res0;
+    @Mock private ResourceDescriptor res1;
+    @Mock private ResourceDescriptor res2;
+
+    @Test
+    void shouldCollectUniqueResources() {
+        // Given:
+        when(collection.resources()).thenAnswer(inv -> Stream.of(res0, res1, res0, res1));
+        when(res0.resources()).thenAnswer(inv -> Stream.of(res1));
+
+        // When:
+        final List<ResourceDescriptor> result =
+                ResourceCollection.collectResources(collection).collect(toList());
+
+        // Then:
+        assertThat(result, containsInAnyOrder(res0, res1));
+    }
+
+    @Test
+    void shouldIgnoreSelfReferences() {
+        // Given:
+        when(collection.resources()).thenAnswer(inv -> Stream.of(res0, res1, collection));
+        when(res0.resources()).thenAnswer(inv -> Stream.of(collection));
+
+        // When:
+        final List<ResourceDescriptor> result =
+                ResourceCollection.collectResources(collection).collect(toList());
+
+        // Then:
+        assertThat(result, containsInAnyOrder(res0, res1));
+    }
+
+    @Test
+    void shouldNotFollowCircularReferences() {
+        // Given:
+        when(collection.resources()).thenAnswer(inv -> Stream.of(res0));
+        when(res0.resources()).thenAnswer(inv -> Stream.of(res1));
+        when(res1.resources()).thenAnswer(inv -> Stream.of(res0, collection));
+
+        // When:
+        final List<ResourceDescriptor> result =
+                ResourceCollection.collectResources(collection).collect(toList());
+
+        // Then:
+        assertThat(result, containsInAnyOrder(res0, res1));
+    }
+
+    @Test
+    void shouldNotFollowingSelfCircularReferences() {
+        // Given:
+        when(collection.resources()).thenAnswer(inv -> Stream.of(res0, res1, collection));
+        when(res0.resources()).thenAnswer(inv -> Stream.of(res0));
+
+        // When:
+        final List<ResourceDescriptor> result =
+                ResourceCollection.collectResources(collection).collect(toList());
+
+        // Then:
+        assertThat(result, containsInAnyOrder(res0, res1));
+    }
+
+    @Test
+    void shouldReturnChildResourcesBeforeParent() {
+        // Given:
+        when(collection.resources()).thenAnswer(inv -> Stream.of(res0));
+        when(res0.resources()).thenAnswer(inv -> Stream.of(res2, res1));
+        when(res1.resources()).thenAnswer(inv -> Stream.of(res2));
+
+        // When:
+        final List<ResourceDescriptor> result =
+                ResourceCollection.collectResources(collection).collect(toList());
+
+        // Then:
+        assertThat(result, is(List.of(res2, res1, res0)));
+    }
+}

--- a/resource/build.gradle.kts
+++ b/resource/build.gradle.kts
@@ -19,9 +19,12 @@ plugins {
 }
 
 val creekVersion : String by extra
+val spotBugsVersion : String by extra
 
 dependencies {
     api(project(":metadata"))
+
     implementation("org.creekservice:creek-base-type:$creekVersion")
     implementation("org.creekservice:creek-observability-logging:$creekVersion")
+    implementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
 }

--- a/resource/src/main/java/module-info.java
+++ b/resource/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module creek.platform.resource {
     requires transitive creek.platform.metadata;
     requires creek.base.type;
     requires creek.observability.logging;
+    requires com.github.spotbugs.annotations;
 
     exports org.creekservice.api.platform.resource;
 }

--- a/resource/src/test/java/org/creekservice/internal/platform/resource/ComponentValidatorTest.java
+++ b/resource/src/test/java/org/creekservice/internal/platform/resource/ComponentValidatorTest.java
@@ -19,6 +19,7 @@ package org.creekservice.internal.platform.resource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,12 +34,11 @@ import org.creekservice.api.platform.metadata.AggregateDescriptor;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ComponentInput;
 import org.creekservice.api.platform.metadata.ComponentInternal;
-import org.creekservice.api.platform.metadata.ComponentOutput;
+import org.creekservice.api.platform.metadata.CreatableResource;
 import org.creekservice.api.platform.metadata.OwnedResource;
 import org.creekservice.api.platform.metadata.ResourceDescriptor;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
 import org.creekservice.api.platform.metadata.SharedResource;
-import org.creekservice.api.platform.metadata.UnownedResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,10 +53,10 @@ class ComponentValidatorTest {
     private static final Pattern CODE_LOCATION =
             Pattern.compile(".*\\(file:/.*creek-platform-metadata-.*\\.jar\\).*", Pattern.DOTALL);
 
-    @Mock(name = "jane")
+    @Mock(name = "bob-text")
     private ServiceDescriptor service;
 
-    @Mock(name = "jane")
+    @Mock(name = "jane-text")
     private AggregateDescriptor aggregate;
 
     private final ComponentValidator validator = new ComponentValidator();
@@ -64,41 +64,9 @@ class ComponentValidatorTest {
     @BeforeEach
     void setUp() {
         when(service.name()).thenReturn("bob");
-        when(aggregate.name()).thenReturn("bob");
+        when(aggregate.name()).thenReturn("jane");
 
         when(service.dockerImage()).thenReturn("image");
-
-        when(service.inputs())
-                .thenReturn(
-                        List.of(
-                                mock(
-                                        ComponentInput.class,
-                                        withSettings().extraInterfaces(UnownedResource.class)),
-                                mock(
-                                        ComponentInput.class,
-                                        withSettings().extraInterfaces(OwnedResource.class)),
-                                mock(
-                                        ComponentInput.class,
-                                        withSettings().extraInterfaces(SharedResource.class))));
-        when(service.internals())
-                .thenReturn(
-                        List.of(
-                                mock(
-                                        ComponentInternal.class,
-                                        withSettings().extraInterfaces(UnownedResource.class)),
-                                mock(
-                                        ComponentInternal.class,
-                                        withSettings().extraInterfaces(OwnedResource.class)),
-                                mock(ComponentInternal.class)));
-        when(service.outputs())
-                .thenReturn(
-                        List.of(
-                                mock(
-                                        ComponentOutput.class,
-                                        withSettings().extraInterfaces(UnownedResource.class)),
-                                mock(
-                                        ComponentOutput.class,
-                                        withSettings().extraInterfaces(OwnedResource.class))));
     }
 
     @Test
@@ -111,7 +79,8 @@ class ComponentValidatorTest {
 
         // Then:
         assertThat(
-                e.getMessage(), containsString("name can not be null or blank, component: jane"));
+                e.getMessage(),
+                containsString("name can not be null or blank, component: bob-text"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
@@ -125,7 +94,8 @@ class ComponentValidatorTest {
 
         // Then:
         assertThat(
-                e.getMessage(), containsString("name can not be null or blank, component: jane"));
+                e.getMessage(),
+                containsString("name can not be null or blank, component: bob-text"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
@@ -194,13 +164,14 @@ class ComponentValidatorTest {
     @Test
     void shouldThrowOnNullResource() {
         // Given:
-        when(service.resources()).thenReturn(Stream.of((ResourceDescriptor) null));
+        when(service.resources()).thenAnswer(inv -> Stream.of((ResourceDescriptor) null));
 
         // When:
         final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
 
         // Then:
-        assertThat(e.getMessage(), containsString("contains null resource, component: bob"));
+        assertThat(e.getMessage(), containsString("contains null resource or resource stream,"));
+        assertThat(e.getMessage(), containsString(", component: bob"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
@@ -209,7 +180,7 @@ class ComponentValidatorTest {
         // Given:
         final ComponentInput resource = mock(ComponentInput.class, withSettings().name("unowned"));
         when(resource.id()).thenReturn(null);
-        when(service.resources()).thenReturn(Stream.of(resource));
+        when(service.resources()).thenAnswer(inv -> Stream.of(resource));
 
         // When:
         final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
@@ -217,7 +188,52 @@ class ComponentValidatorTest {
         // Then:
         assertThat(
                 e.getMessage(), containsString("null resource id, resource_type: ComponentInput$"));
+        assertThat(e.getMessage(), not(containsString(", resource:")));
         assertThat(e.getMessage(), containsString("component: bob"));
+        assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
+    }
+
+    @Test
+    void shouldThrowOnIssuesWithNestedResources() {
+        // Given:
+        final ComponentInput bad = mock(ComponentInput.class, withSettings().name("bad"));
+        when(bad.id()).thenReturn(null);
+
+        final ComponentInput indirect = mock(ComponentInput.class, withSettings().name("indirect"));
+        when(indirect.id()).thenReturn(URI.create("res:indirect"));
+        when(indirect.resources()).thenAnswer(inv -> Stream.of(bad));
+
+        final ComponentInput direct = mock(ComponentInput.class, withSettings().name("direct"));
+        when(direct.id()).thenReturn(URI.create("res:direct"));
+        when(direct.resources()).thenAnswer(inv -> Stream.of(indirect));
+
+        when(service.resources()).thenAnswer(inv -> Stream.of(direct));
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
+
+        // Then:
+        assertThat(
+                e.getMessage(), containsString("null resource id, resource_type: ComponentInput$"));
+        assertThat(e.getMessage(), containsString(", component: bob "));
+        assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
+    }
+
+    @Test
+    void shouldThrowOnIssuesWithResourceReturningNullResourceStream() {
+        // Given:
+        final ComponentInput bad = mock(ComponentInput.class, withSettings().name("bad"));
+        when(bad.id()).thenReturn(URI.create("not-null"));
+        when(bad.resources()).thenReturn(null);
+
+        when(service.resources()).thenAnswer(inv -> Stream.of(bad));
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
+
+        // Then:
+        assertThat(e.getMessage(), containsString("contains null resource or resource stream,"));
+        assertThat(e.getMessage(), containsString(", component: bob"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
@@ -236,36 +252,74 @@ class ComponentValidatorTest {
         assertThat(
                 e.getMessage(),
                 containsString(
-                        "Aggregate should not expose internal resources. internals: [internal],"
-                                + " component: bob"));
-        assertThat(e.getMessage(), containsString("component: bob"));
+                        "Aggregate should not expose internal resources. internals: [internal]"));
+        assertThat(e.getMessage(), containsString(", component: jane"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
     @Test
     void shouldThrowIfAggregateExposesNonOwnedResources() {
         // Given:
-        when(aggregate.resources())
-                .thenReturn(Stream.of(mock(ComponentInput.class, withSettings().name("unowned"))));
+        final ComponentInput unowned = mock(ComponentInput.class, withSettings().name("unowned"));
+        when(unowned.id()).thenReturn(URI.create("not-null"));
+
+        when(aggregate.resources()).thenAnswer(inv -> Stream.of(unowned));
 
         // When:
         final Exception e =
                 assertThrows(RuntimeException.class, () -> validator.validate(aggregate));
 
         // Then:
-        assertThat(
-                e.getMessage(),
-                containsString(
-                        "Aggregate should only expose OwnedResource. not_owned: [unowned],"
-                                + " component: bob"));
-        assertThat(e.getMessage(), containsString("component: bob"));
+        assertThat(e.getMessage(), containsString("Aggregate should only expose OwnedResource."));
+        assertThat(e.getMessage(), containsString(". not_owned: [unowned]"));
+        assertThat(e.getMessage(), containsString(", component: jane"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
     @Test
-    void shouldThrowIfResourceImplementsMultipleInitializationMarkers() {
+    void shouldThrowIfAggregateExposesNestedNonOwnedResources() {
         // Given:
-        when(service.resources()).thenReturn(Stream.of(new BadResourceDescriptor()));
+        final ComponentInput unowned = mock(ComponentInput.class, withSettings().name("unowned"));
+        when(unowned.id()).thenReturn(URI.create("res:unowned"));
+
+        final ComponentInput indirect =
+                mock(
+                        ComponentInput.class,
+                        withSettings().extraInterfaces(OwnedResource.class).name("indirect"));
+        when(indirect.id()).thenReturn(URI.create("res:indirect"));
+        when(indirect.resources()).thenAnswer(inv -> Stream.of(unowned));
+
+        final ComponentInput direct =
+                mock(
+                        ComponentInput.class,
+                        withSettings().extraInterfaces(OwnedResource.class).name("direct"));
+        when(direct.id()).thenReturn(URI.create("res:direct"));
+        when(direct.resources()).thenAnswer(inv -> Stream.of(indirect));
+
+        when(aggregate.resources()).thenAnswer(inv -> Stream.of(direct));
+
+        // When:
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> validator.validate(aggregate));
+
+        // Then:
+        assertThat(e.getMessage(), containsString("Aggregate should only expose OwnedResource."));
+        assertThat(e.getMessage(), containsString(". not_owned: [unowned]"));
+        assertThat(e.getMessage(), containsString(", component: jane"));
+        assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
+    }
+
+    @Test
+    void shouldThrowIfResourceImplementsMultipleInitializationInterfaces() {
+        // Given:
+        final ComponentInput bad =
+                mock(
+                        ComponentInput.class,
+                        withSettings()
+                                .extraInterfaces(SharedResource.class, OwnedResource.class)
+                                .name("bad"));
+        when(bad.id()).thenReturn(URI.create("bad:resource"));
+        when(service.resources()).thenAnswer(inv -> Stream.of(bad));
 
         // When:
         final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
@@ -274,10 +328,34 @@ class ComponentValidatorTest {
         assertThat(
                 e.getMessage(),
                 containsString(
-                        "resource can implement at-most one ResourceInitialization marker"
-                                + " interface, but was: [OwnedResource, SharedResource], resource:"
-                                + " bad:resource"));
-        assertThat(e.getMessage(), containsString("component: bob"));
+                        "resource can implement at-most one resource initialization interface"
+                                + ", but was: [OwnedResource, SharedResource]"));
+        assertThat(e.getMessage(), containsString(", resource: bad:resource"));
+        assertThat(e.getMessage(), containsString(", component: bob"));
+        assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
+    }
+
+    @Test
+    void shouldThrowIfResourceImplementsCreatableButNotOwnedOrShared() {
+        // Given:
+        final ComponentInput bad =
+                mock(
+                        ComponentInput.class,
+                        withSettings().extraInterfaces(CreatableResource.class).name("bad"));
+        when(bad.id()).thenReturn(URI.create("bad:resource"));
+        when(service.resources()).thenAnswer(inv -> Stream.of(bad));
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> validator.validate(service));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "creatable resource must implement either the SharedResource or the"
+                                + " OwnedResource interface,"));
+        assertThat(e.getMessage(), containsString(", resource: bad:resource"));
+        assertThat(e.getMessage(), containsString(", component: bob"));
         assertThat(e.getMessage(), matchesRegex(CODE_LOCATION));
     }
 
@@ -331,6 +409,26 @@ class ComponentValidatorTest {
         validator.validate(service);
     }
 
+    @Test
+    void shouldWorkWithCircularResourceReferences() {
+        // Given:
+        final ComponentInput indirect = mock(ComponentInput.class, withSettings().name("indirect"));
+        when(indirect.id()).thenReturn(URI.create("res:indirect"));
+
+        final ComponentInput direct = mock(ComponentInput.class, withSettings().name("direct"));
+        when(direct.id()).thenReturn(URI.create("res:direct"));
+
+        when(indirect.resources()).thenAnswer(inv -> Stream.of(direct));
+        when(direct.resources()).thenAnswer(inv -> Stream.of(indirect));
+
+        when(service.resources()).thenAnswer(inv -> Stream.of(direct));
+
+        // When:
+        validator.validate(service);
+
+        // Then: did not throw
+    }
+
     private static final class OverridingServiceDescriptor implements ServiceDescriptor {
         @Override
         public String name() {
@@ -357,15 +455,6 @@ class ComponentValidatorTest {
         @Override
         public String dockerImage() {
             return "image";
-        }
-    }
-
-    private static final class BadResourceDescriptor
-            implements ResourceDescriptor, SharedResource, OwnedResource {
-
-        @Override
-        public URI id() {
-            return URI.create("bad:resource");
         }
     }
 }


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-platform/issues/181

- Adds support for one resource descriptor to expose dependencies on other resources.
- Removes unnecessary methods on `ResourceDescriptor`.
- Ensure all resource interfaces derive from `ResourceDescriptor`.
